### PR TITLE
change api of object().schema()

### DIFF
--- a/Documentation.md
+++ b/Documentation.md
@@ -322,11 +322,11 @@ Alt.object().schema(
 ```javascript
 // 'a', 'b', 'c', 'd'
 // - none of them are required
-Alt.object().oneOf('a', 'b', 'c', 'd')
+Alt.object().oneOf('a', 'b', 'c', 'd');
 
 // 'a', 'b'
 // - one of them is required
-Alt.object().oneOf(true, 'a', 'b')
+Alt.object().oneOf(true, 'a', 'b');
 ```
 
 ----

--- a/Documentation.md
+++ b/Documentation.md
@@ -219,7 +219,7 @@ Alt.string().if({
 //
 ```
 
-#### `validate(:mixed[, :func])`
+#### `validate(:mixed [, :func])`
 > If you want to, you can validate only one input without the whole schema.
 > You can await or pass callback
 
@@ -258,13 +258,13 @@ Alt.string().max(5);
 Alt.string().pattern(/^[a-z]$/);
 ```
 
-#### `in(value [,value...])`
+#### `in(...value)`
 > Force a string to be equal to one of the value passed in the set.
 ```javascript
 Alt.string().in('foo', 'bar');
 ```
 
-#### `not(value [,value...])`
+#### `not(...value)`
 > Force a string to be different to all of the value passed in the set.
 ```javascript
 Alt.string().not('bar', 'foo');
@@ -291,13 +291,13 @@ Alt.string().uppercase();
 ----
 
 ### Object
-#### `in(value [,value...])`
+#### `in(...value)`
 > Force an object to have only the keys passed in the set
 ```javascript
 Alt.object().in('foo', 'bar');
 ```
 
-#### `not(value [,value...])`
+#### `not(...value)`
 > Force an object to not have the keys passed in the set
 ```javascript
 Alt.object().not('foo', 'bar');
@@ -327,6 +327,13 @@ Alt.object().oneOf('a', 'b', 'c', 'd');
 // 'a', 'b'
 // - one of them is required
 Alt.object().oneOf(true, 'a', 'b');
+```
+
+#### `allOf(...keys :string)`
+> Force all keys to be mutually required. If one is presents, all are required. Pass if none are present.
+
+```javascript
+Alt.object().allOf('a', 'b', 'c');
 ```
 
 ----
@@ -395,13 +402,13 @@ Alt.number().positive();
 Alt.number().negative();
 ```
 
-#### `in(value [,value...])`
+#### `in(...value)`
 > Force a number to be equal to one of the value passed in the set.
 ```javascript
 Alt.number().in(1, 35);
 ```
 
-#### `not(value [,value...])`
+#### `not(...value)`
 > Force a number to be different to all of the value passed in the set.
 ```javascript
 Alt.number().not(42, 157);
@@ -422,13 +429,13 @@ Alt.array().min(5);
 Alt.array().max(10);
 ```
 
-#### `in(value [,value...])`
+#### `in(...value)`
 > Force an array to have only the keys passed in the set
 ```javascript
 Alt.array().in('foo', 'bar');
 ```
 
-#### `not(value [,value...])`
+#### `not(...value)`
 > Force an array not to have the keys passed in the set
 ```javascript
 Alt.object().not('foo', 'bar');

--- a/Documentation.md
+++ b/Documentation.md
@@ -303,16 +303,17 @@ Alt.object().in('foo', 'bar');
 Alt.object().not('foo', 'bar');
 ```
 
-#### `schema({ schema :Validator, returnErrors :bool })`
-> Check an object with the passed schema. It will help you check nested object without effort. Because schema need to be instance of Altheia, you can do whatever you want without restriction. `returnErrors` to `true` will return errors with the main payload if any.
+#### `schema(schema :Validator, { returnErrors :bool })`
+> Check an object with the passed schema. It will help you check nested object without effort. Because schema need to be instance of Altheia, you can do whatever you want without restriction.
+Second params is optionnal:
+`returnErrors` to `true` will return errors with the main payload if any.
 ```javascript
-Alt.object().schema({
-    schema: Alt({
-            foo: Alt.string(),
-            bar: Alt.number(),
-        }).options({ required: true }),
-    returnErrors: true,
-});
+Alt.object().schema(
+    Alt({
+        foo: Alt.string(),
+        bar: Alt.number(),
+    }).options({ required: true })
+);
 ```
 
 ----

--- a/Documentation.md
+++ b/Documentation.md
@@ -316,6 +316,19 @@ Alt.object().schema(
 );
 ```
 
+#### `oneOf(isOneRequired :boolean, ...keys :string)`
+> Force any keys, to be the only one present in the object (exclusive relationships)
+`oneIsRequired` is false by default
+```javascript
+// 'a', 'b', 'c', 'd'
+// - none of them are required
+Alt.object().oneOf('a', 'b', 'c', 'd')
+
+// 'a', 'b'
+// - one of them is required
+Alt.object().oneOf(true, 'a', 'b')
+```
+
 ----
 
 ### Date

--- a/src/base.js
+++ b/src/base.js
@@ -22,6 +22,7 @@ module.exports = class Base {
       func,
       args,
       isValid: true,
+      result: {},
     });
   }
 
@@ -62,19 +63,28 @@ module.exports = class Base {
       } else {
         const result = await test.func(toTest);
         const resultIsObject = isPlainObject(result);
+
+        // Check result format
+        let isResultOkay = true;
         if (resultIsObject) {
           if (
             typeof result.isValid === 'undefined' ||
             typeof result.error === 'undefined'
           ) {
-            throw new Error(
-              'test() should return a boolean or an object { isValid:boolean, error:string }'
-            );
+            isResultOkay = false;
           }
+        } else if (typeof result !== 'boolean') {
+          isResultOkay = false;
+        }
+
+        if (!isResultOkay) {
+          throw new Error(
+            'test() should return a boolean or an object { isValid:boolean, error:string }'
+          );
         }
 
         test.isValid = resultIsObject ? result.isValid : result;
-        test.args._result = resultIsObject ? result : {};
+        test.result = resultIsObject ? result : {};
       }
 
       // Do not go deeper in test
@@ -107,6 +117,12 @@ module.exports = class Base {
    * @param  {Function} callback
    */
   custom(name, callback, message) {
+    if (typeof name !== 'string') {
+      throw new Error(
+        'first param of custom() must the unique name of this test'
+      );
+    }
+
     this.test(
       `custom.${name}`,
       async (str) => {

--- a/src/base.js
+++ b/src/base.js
@@ -1,3 +1,5 @@
+const isPlainObject = require('lodash/isPlainObject');
+
 module.exports = class Base {
   constructor() {
     this._required = false;
@@ -58,7 +60,21 @@ module.exports = class Base {
       if (test.name.indexOf('.if') >= 0) {
         test = await test.func(toTest);
       } else {
-        test.isValid = await test.func(toTest);
+        const result = await test.func(toTest);
+        const resultIsObject = isPlainObject(result);
+        if (resultIsObject) {
+          if (
+            typeof result.isValid === 'undefined' ||
+            typeof result.error === 'undefined'
+          ) {
+            throw new Error(
+              'test() should return a boolean or an object { isValid:boolean, error:string }'
+            );
+          }
+        }
+
+        test.isValid = resultIsObject ? result.isValid : result;
+        test.args._result = resultIsObject ? result : {};
       }
 
       // Do not go deeper in test

--- a/src/index.js
+++ b/src/index.js
@@ -54,11 +54,11 @@ const Instance = (lang) => {
     return inst.templates[name].clone();
   };
 
-  inst.formatError = ({ name, args }, label = 'value') => {
+  inst.formatError = ({ name, args, result }, label = 'value') => {
     // Get messages from error
     let msg;
     if (typeof inst.langList[name] !== 'undefined') {
-      msg = inst.langList[name](label, args);
+      msg = inst.langList[name](label, args, result);
     } else {
       msg = 'Invalid value';
     }

--- a/src/internet.js
+++ b/src/internet.js
@@ -51,7 +51,8 @@ module.exports.Class = class internet extends Base {
         }
 
         // eslint-disable-next-line
-        return new URL(str);
+        new URL(str);
+        return true;
       } catch (e) {
         return false;
       }
@@ -78,11 +79,11 @@ module.exports.Class = class internet extends Base {
       if (/[^0-9-\s]+/.test(str)) {
         return false;
       }
-      str = str.replace(/\D/, '');
+      str = str.replace(/\D/g, '');
       if (str.length < 13) {
         return false;
       }
-      return Luhn(str);
+      return Luhn(str) === true;
     });
     return this;
   }

--- a/src/object.js
+++ b/src/object.js
@@ -82,7 +82,6 @@ module.exports.Class = class object extends Base {
       }
 
       const Alt = require('./index');
-      console.log('schema', schema);
       schema = Alt(schema);
     }
 
@@ -96,4 +95,69 @@ module.exports.Class = class object extends Base {
     );
     return this;
   }
+
+  oneOf(...params) {
+    if (params.length <= 1) {
+      throw new Error('oneOf expect at least 2 params');
+    }
+
+    let oneIsRequired = false;
+    let keys = [];
+    if (typeof params[0] === 'boolean') {
+      oneIsRequired = params[0];
+      keys = params.splice(1);
+    } else {
+      keys = params;
+    }
+
+    this.test(
+      'oneOf',
+      async (obj) => {
+        const presence = { a: null, b: null };
+
+        try {
+          Object.keys(obj).forEach((key) => {
+            if (keys.includes(key)) {
+              if (!presence.a) {
+                presence.a = key;
+              } else if (!presence.b) {
+                presence.b = key;
+                throw new Error('a and b can not be present at the same time');
+              }
+            }
+          });
+        } catch (e) {
+          return false;
+        }
+
+        if (oneIsRequired && !presence.a && !presence.b) {
+          return false;
+        }
+
+        return true;
+        // return (!obj[keyA] && !obj[keyB] && oneIsRequired === false)
+        //   || typeof obj[keyA] !== 'undefined' && !obj[keyB]
+        //   || !obj[keyA] && typeof obj[keyB] !== 'undefined';
+      },
+      { oneIsRequired, keys }
+    );
+    return this;
+  }
+
+  // group(keyA, ...keyB) {
+  //   this.test(
+  //     'schema',
+  //     async (obj) => {
+  //       return !obj[keyA] ||
+  //         !obj[keyA] && Object.keys(obj).reduce((acc, k) => {
+  //           if (keyB.indexOf(k)) {
+  //             acc += 1;
+  //           }
+  //           return acc;
+  //         }, 0) === keyB.length;
+  //     },
+  //     { keyA, keyB }
+  //   );
+  //   return this;
+  // }
 };

--- a/src/object.js
+++ b/src/object.js
@@ -9,6 +9,17 @@ module.exports.lang = {
     `${name} must only contains these keys [${args.in}]`,
   'object.not': (name) => `${name} contains forbidden value`,
   'object.schema': (name) => `${name} has not a valid schema`,
+  'object.oneOf': (name, args) => {
+    if (args._result.error === 'oneIsRequired') {
+      return `${name} should contain one of these keys [${args.keys}]`;
+    }
+    if (args._result.keys) {
+      return `${name} can not contain these two keys [${
+        args._result.keys
+      }] at the same time`;
+    }
+    return 'unknown error';
+  },
 };
 
 module.exports.Class = class object extends Base {
@@ -127,11 +138,15 @@ module.exports.Class = class object extends Base {
             }
           });
         } catch (e) {
-          return false;
+          return {
+            isValid: false,
+            error: 'exclusion',
+            keys: Object.values(presence),
+          };
         }
 
         if (oneIsRequired && !presence.a && !presence.b) {
-          return false;
+          return { isValid: false, error: 'oneIsRequired' };
         }
 
         return true;

--- a/src/object.js
+++ b/src/object.js
@@ -9,13 +9,13 @@ module.exports.lang = {
     `${name} must only contains these keys [${args.in}]`,
   'object.not': (name) => `${name} contains forbidden value`,
   'object.schema': (name) => `${name} has not a valid schema`,
-  'object.oneOf': (name, args) => {
-    if (args._result.error === 'oneIsRequired') {
+  'object.oneOf': (name, args, result) => {
+    if (result.error === 'oneIsRequired') {
       return `${name} must contain one of these keys [${args.keys}]`;
     }
-    if (args._result.keys) {
+    if (result.keys) {
       return `${name} can not contain these two keys [${
-        args._result.keys
+        result.keys
       }] at the same time`;
     }
     return 'unknown error';

--- a/src/object.js
+++ b/src/object.js
@@ -11,7 +11,7 @@ module.exports.lang = {
   'object.schema': (name) => `${name} has not a valid schema`,
   'object.oneOf': (name, args) => {
     if (args._result.error === 'oneIsRequired') {
-      return `${name} should contain one of these keys [${args.keys}]`;
+      return `${name} must contain one of these keys [${args.keys}]`;
     }
     if (args._result.keys) {
       return `${name} can not contain these two keys [${
@@ -20,6 +20,8 @@ module.exports.lang = {
     }
     return 'unknown error';
   },
+  'object.allOf': (name, args) =>
+    `${name} must contain either none or all of these keys [${args.keys}]`,
 };
 
 module.exports.Class = class object extends Base {
@@ -156,20 +158,21 @@ module.exports.Class = class object extends Base {
     return this;
   }
 
-  // group(keyA, ...keyB) {
-  //   this.test(
-  //     'schema',
-  //     async (obj) => {
-  //       return !obj[keyA] ||
-  //         !obj[keyA] && Object.keys(obj).reduce((acc, k) => {
-  //           if (keyB.indexOf(k)) {
-  //             acc += 1;
-  //           }
-  //           return acc;
-  //         }, 0) === keyB.length;
-  //     },
-  //     { keyA, keyB }
-  //   );
-  //   return this;
-  // }
+  allOf(...keys) {
+    this.test(
+      'allOf',
+      async (obj) => {
+        return (
+          Object.keys(obj).reduce((acc, k) => {
+            if (keys.includes(k)) {
+              acc += 1;
+            }
+            return acc;
+          }, 0) === keys.length
+        );
+      },
+      { keys }
+    );
+    return this;
+  }
 };

--- a/src/object.js
+++ b/src/object.js
@@ -61,11 +61,29 @@ module.exports.Class = class object extends Base {
     return this;
   }
 
-  schema({ schema, returnErrors = false }) {
+  schema(schema, { returnErrors = false } = {}) {
+    // old api
+    if (isPlainObject(schema) && schema.schema) {
+      if (typeof schema.returnErrors !== 'undefined') {
+        returnErrors = schema.returnErrors;
+      }
+      schema = schema.schema;
+    }
+
     if (typeof schema.isValidator === 'undefined') {
-      throw new Error(
-        'argument should be an instance of altheia validator "Alt({ ... })"'
-      );
+      if (!isPlainObject(schema)) {
+        throw new Error(
+          'schema should be an instance of altheia validator "Alt({ ... })" or a plain object'
+        );
+      }
+
+      if (Object.keys(schema).length <= 0) {
+        throw new Error('schema should have one key at least');
+      }
+
+      const Alt = require('./index');
+      console.log('schema', schema);
+      schema = Alt(schema);
     }
 
     this.test(

--- a/src/object.js
+++ b/src/object.js
@@ -135,9 +135,6 @@ module.exports.Class = class object extends Base {
         }
 
         return true;
-        // return (!obj[keyA] && !obj[keyB] && oneIsRequired === false)
-        //   || typeof obj[keyA] !== 'undefined' && !obj[keyB]
-        //   || !obj[keyA] && typeof obj[keyB] !== 'undefined';
       },
       { oneIsRequired, keys }
     );

--- a/test/base.test.js
+++ b/test/base.test.js
@@ -45,12 +45,29 @@ describe('Base', () => {
       expect(hasError).toBeTruthy();
       expect(hasError.result.error).toEqual('not_okay');
     });
-    test('should fail if not a boolean or a valid object', async () => {
+    test('should fail if result is string', async () => {
       let error;
       try {
         await Alt.string()
           .custom('dfd', () => {
             return 'nope';
+          })
+          .validate('foobar');
+      } catch (e) {
+        error = e;
+      }
+      expect(error).toEqual(
+        new Error(
+          'test() should return a boolean or an object { isValid:boolean, error:string }'
+        )
+      );
+    });
+    test('should fail if not a valid object', async () => {
+      let error;
+      try {
+        await Alt.string()
+          .custom('dfd', () => {
+            return { foo: 'bar' };
           })
           .validate('foobar');
       } catch (e) {

--- a/test/base.test.js
+++ b/test/base.test.js
@@ -33,6 +33,37 @@ describe('Base', () => {
     expect(mark).toBe(true);
   });
 
+  describe('test()', () => {
+    test('should understand object response', async () => {
+      const hasError = await Alt.string()
+        .custom('mytest', () => {
+          return { isValid: false, error: 'not_okay' };
+        })
+        .validate('foobar');
+
+      // to avoid false positive we check the callback real use
+      expect(hasError).toBeTruthy();
+      expect(hasError.result.error).toEqual('not_okay');
+    });
+    test('should fail if not a boolean or a valid object', async () => {
+      let error;
+      try {
+        await Alt.string()
+          .custom('dfd', () => {
+            return 'nope';
+          })
+          .validate('foobar');
+      } catch (e) {
+        error = e;
+      }
+      expect(error).toEqual(
+        new Error(
+          'test() should return a boolean or an object { isValid:boolean, error:string }'
+        )
+      );
+    });
+  });
+
   describe('clone()', () => {
     test('should clone correctly', async () => {
       const original = Alt.string().required();

--- a/test/internet.test.js
+++ b/test/internet.test.js
@@ -195,14 +195,14 @@ describe('String', () => {
       const hasError = await alt
         .internet()
         .creditCard()
-        .validate('2221 0012 3412 3456');
+        .validate('4111 1111 1111 1111');
       expect(hasError).toBe(false);
     });
     test('should pass: formatted union', async () => {
       const hasError = await alt
         .internet()
         .creditCard()
-        .validate('2221-0012-3412-3456');
+        .validate('4111-1111-1111-1111');
       expect(hasError).toBe(false);
     });
     test('should not pass: string int', async () => {

--- a/test/object.test.js
+++ b/test/object.test.js
@@ -280,7 +280,33 @@ describe('Object', () => {
       expect(Alt.formatError(hasError)).toEqual({
         label: 'value',
         type: 'object.oneOf',
-        message: 'value should contain one of these keys [a,b]',
+        message: 'value must contain one of these keys [a,b]',
+      });
+    });
+  });
+
+  describe('allOf()', () => {
+    test('should pass: a, b, c', async () => {
+      const hasError = await Alt.object()
+        .allOf('a', 'b', 'c')
+        .validate({ a: 1, b: 2, c: 3 });
+      expect(hasError).toBe(false);
+    });
+    test('should not pass: a,  c', async () => {
+      const hasError = await Alt.object()
+        .allOf('a', 'b', 'c')
+        .validate({ a: 1, c: 3 });
+      expect(hasError).toBeTruthy();
+    });
+    test('should not pass: none', async () => {
+      const hasError = await Alt.object()
+        .allOf('a', 'b', 'c')
+        .validate({ z: 1 });
+      expect(hasError).toBeTruthy();
+      expect(Alt.formatError(hasError)).toEqual({
+        label: 'value',
+        type: 'object.allOf',
+        message: 'value must contain either none or all of these keys [a,b,c]',
       });
     });
   });

--- a/test/object.test.js
+++ b/test/object.test.js
@@ -136,6 +136,18 @@ describe('Object', () => {
         .validate({ foo: 'bar' });
       expect(hasError).toBe(false);
     });
+
+    test('should pass (new api)', async () => {
+      const hasError = await Alt.object()
+        .schema(
+          Alt({
+            foo: Alt.string(),
+          }).options({ required: true })
+        )
+        .validate({ foo: 'bar' });
+      expect(hasError).toBe(false);
+    });
+
     test('should fail', async () => {
       const hasError = await Alt.object()
         .schema({
@@ -151,6 +163,7 @@ describe('Object', () => {
         message: 'value has not a valid schema',
       });
     });
+
     test('should fail not valid schema', async () => {
       expect(() => {
         Alt.object().schema({
@@ -158,6 +171,7 @@ describe('Object', () => {
         });
       }).toThrow();
     });
+
     test('should fail deep', async () => {
       const hasError = await Alt({
         data: Alt.object().schema({
@@ -166,6 +180,36 @@ describe('Object', () => {
           }).options({ required: true }),
           returnErrors: true,
         }),
+      })
+        .body({ data: { foo: 'bar' } })
+        .validate();
+      expect(hasError).toBeTruthy();
+      expect(hasError).toEqual([
+        {
+          label: 'data',
+          type: 'object.schema',
+          message: 'data has not a valid schema',
+          errors: [
+            {
+              label: 'foo',
+              message: 'foo must be a valid number',
+              type: 'number.typeof',
+            },
+          ],
+        },
+      ]);
+    });
+
+    test('should fail deep (new api)', async () => {
+      const hasError = await Alt({
+        data: Alt.object().schema(
+          Alt({
+            foo: Alt.number(),
+          }).options({ required: true }),
+          {
+            returnErrors: true,
+          }
+        ),
       })
         .body({ data: { foo: 'bar' } })
         .validate();

--- a/test/object.test.js
+++ b/test/object.test.js
@@ -229,6 +229,25 @@ describe('Object', () => {
         },
       ]);
     });
+
+    test('should fail bad parameter schema', async () => {
+      expect(() => {
+        Alt.object().schema(new Error());
+      }).toThrow(
+        'schema should be an instance of altheia validator "Alt({ ... })" or a plain object'
+      );
+    });
+
+    test('should pass, plain object', async () => {
+      const hasError = await Alt({
+        data: Alt.object().schema({
+          foo: Alt.number(),
+        }),
+      })
+        .body({ data: { foo: 1 } })
+        .validate();
+      expect(hasError).toBe(false);
+    });
   });
 
   describe('oneOf()', () => {

--- a/test/object.test.js
+++ b/test/object.test.js
@@ -231,6 +231,50 @@ describe('Object', () => {
     });
   });
 
+  describe('oneOf()', () => {
+    test('should pass: a', async () => {
+      const hasError = await Alt.object()
+        .oneOf('a', 'b')
+        .validate({ a: 1 });
+      expect(hasError).toBe(false);
+    });
+
+    test('should pass: b', async () => {
+      const hasError = await Alt.object()
+        .oneOf('a', 'b')
+        .validate({ b: 1 });
+      expect(hasError).toBe(false);
+    });
+
+    test('should pass: a b d e f j...', async () => {
+      const hasError = await Alt.object()
+        .oneOf('a', 'b', 'c', 'd', 'e', 'f')
+        .validate({ d: 1 });
+      expect(hasError).toBe(false);
+    });
+
+    test('should not pass: both presents', async () => {
+      const hasError = await Alt.object()
+        .oneOf('a', 'b')
+        .validate({ a: 1, b: 1 });
+      expect(hasError).toBeTruthy();
+    });
+
+    test('should pass: none presents, without flag', async () => {
+      const hasError = await Alt.object()
+        .oneOf('a', 'b')
+        .validate({});
+      expect(hasError).toBe(false);
+    });
+
+    test('should not pass: none presents, with flag', async () => {
+      const hasError = await Alt.object()
+        .oneOf(true, 'a', 'b')
+        .validate({});
+      expect(hasError).toBeTruthy();
+    });
+  });
+
   describe('required()', () => {
     test('should pass', async () => {
       const hasError = await Alt.object()

--- a/test/object.test.js
+++ b/test/object.test.js
@@ -258,6 +258,11 @@ describe('Object', () => {
         .oneOf('a', 'b')
         .validate({ a: 1, b: 1 });
       expect(hasError).toBeTruthy();
+      expect(Alt.formatError(hasError)).toEqual({
+        label: 'value',
+        type: 'object.oneOf',
+        message: 'value can not contain these two keys [a,b] at the same time',
+      });
     });
 
     test('should pass: none presents, without flag', async () => {
@@ -272,6 +277,11 @@ describe('Object', () => {
         .oneOf(true, 'a', 'b')
         .validate({});
       expect(hasError).toBeTruthy();
+      expect(Alt.formatError(hasError)).toEqual({
+        label: 'value',
+        type: 'object.oneOf',
+        message: 'value should contain one of these keys [a,b]',
+      });
     });
   });
 

--- a/test/validator.test.js
+++ b/test/validator.test.js
@@ -358,7 +358,7 @@ describe('Validator', () => {
           return new Promise((resolve) => {
             setTimeout(() => {
               mark = true;
-              resolve();
+              resolve(true);
             }, 500);
           });
         }),


### PR DESCRIPTION
Closes #2 

- Change api of .schema() (retro-compatible)
```javascript
#Before
.schema({ schema :Validator, returnErrors :bool });

#After
.schema(schema :Validator, { returnErrors :bool });
```

- Add .oneOf()
```javascript
.oneOf([[boolean, ...keys:string], ...keys:string]);

// 'a', 'b', 'c', 'd' 
// - can not present at the same time
// - none of them a required
.oneOf('a', 'b', 'c', 'd')

// 'a', 'b', 'c', 'd' 
// - can not present at the same time
// - one of them is required
.oneOf(true, 'a', 'b', 'c', 'd')
```


- add `allOf(...keys :string)`
> Force all keys to be mutually required. If one is presents, all are required. Pass if none are present.

```javascript
Alt.object().allOf('a', 'b', 'c');
```
