### PR TITLE
chore(doc): typos & small things

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,10 +39,10 @@ yarn add altheia-async-data-validator
 ```javascript
 import alt from 'altheia-async-data-validator'
 
-alt.lang('string.min', (name, args) => `This ${name} is too short`});
+alt.lang('string.min', (name, args) => `This ${name} is too short`);
 alt.template('login', alt.string().min(3).not('admin'));
 
-const errors = await Alt({
+const errors = await alt({
     login: alt.is('login'),
     email: alt.string()
         .email()

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,9 +4,9 @@ Online version: [github.io/altheia/](https://bodinsamuel.github.io/altheia/)
 
 ## 🤓 Why?
 
-After searching for a long time a simple data validator that allow async validation, I decided to implement one. Heavily inspired from Joi, it aim at being very lightweight, simple to use and allow to check anything from standard schema to very custom ones.
+After searching for a long time a simple data validator that allow async validation, I decided to implement one. Heavily inspired from Joi, it aims at being very lightweight, simple to use and allow checking anything from a standard schema to very custom ones.
 
-The goal of this library is to validate json -- for example in express middleware -- and complexe javascript object.
+The goal of this library is to validate json -- for example in express middleware -- and complex javascript object.
 
 - 💅 **Easy to customize.** Use builtin or create your own validation.
 - ⚡️**Async.** Call any resources asynchronously to do check your data (e.g: database, xhr...)
@@ -30,10 +30,10 @@ One simple step, import the library
 ```javascript
 import alt from 'altheia-async-data-validator';
 // or
-const alt = require('altheia-async-data-validator');
+const alt = require('altheia-async-data-validator').default;
 ```
 
-Typescript definitions are builtin the library, no need to install an other package.
+Typescript definitions are builtin the library, no need to install another package.
 
 ## Core Concepts
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -3,10 +3,14 @@
 To start using Altheia, require the package this way:
 
 ```js
+// TS
 import alt from 'altheia-async-data-validator';
+
+// js
+const alt = require('altheia-async-data-validator').default
 ```
 
-This documentation presents all available methods but you can also refer to the **Typescript definitions** in your IDE.
+This documentation presents all available methods, but you can also refer to the **Typescript definitions** in your IDE.
 
 - [Main](#main)
   - [`validate()`](#validatebody-object-callbackfunc)
@@ -103,7 +107,7 @@ const hasError = await alt(...).body({
 
 ### `clone()`
 
-> Once a Validator has been validated, it carry on the results. You can clone it to clean the class and validate an other body. It's ligth, it simply pass the schema reference without copying the results.
+> Once a Validator has been validated, it carry on the results. You can clone it to clean the class and validate another body. It's light, it simply passes the schema reference without copying the results.
 
 ```javascript
 const schema = alt({
@@ -132,7 +136,7 @@ alt({
 
 ### `confirm(key1: string, key2: string)`
 
-> Because a single value validation can not share any context with one another -- because everything is async -- confirmation is being done after in the global schema validation.
+> Because a single value validation cannot share any context with one another -- because everything is async -- confirmation is being done after in the global schema validation.
 
 ```javascript
 alt({
@@ -157,7 +161,7 @@ alt.lang('string.min', () => `not good`);
 
 ```javascript
 alt.use({
-    messages: { ...}
+    messages: { ... }
     Class: class foobar extends alt.Base {}
 });
 ```
@@ -240,9 +244,9 @@ alt.any().if({
 > You can await or pass callback
 
 ```javascript
-const hasError = await Api.string().validate(1);
+const hasError = await alt.string().validate(1);
 //=> :false if no error
-//=> :object if not
+//=> :ValidatorTestResult if not
 ```
 
 ---
@@ -251,7 +255,7 @@ const hasError = await Api.string().validate(1);
 
 > Any plugins is loaded by default since v3.0.0
 
-Any inherit global methods and that's it. It allow chaining without knowing the type.
+Any inherits global methods and that's it. It allows chaining without knowing the type.
 
 ```javascript
 alt.any().required().custom();
@@ -280,7 +284,7 @@ alt.string().min(1);
 
 ### string().`max(:int)`
 
-> Force a string to have lenght of equal or less to the value passed.
+> Force a string to have length of equal or less to the value passed.
 
 ```javascript
 alt.string().max(5);
@@ -404,7 +408,7 @@ alt.number().in(67, 35);
 
 ### number().`not(...value)`
 
-> Force a number to be different to all of the values passed in the set.
+> Force a number to be different to all the values passed in the set.
 
 ```javascript
 alt.number().not(42, 157);
@@ -442,7 +446,7 @@ alt.object().not('foo', 'bar');
 
 > Check an object with the passed schema. It will help you check nested object without effort. Because schema need to be instance of Altheia, you can do whatever you want without restriction.
 
-Accept an optionnal second param:
+Accept an optional second param:
 
 - `returnErrors: boolean` => `false` will not display nested errors.
 
@@ -460,7 +464,7 @@ alt.object().schema(
 
 > Force any keys, to be the only one present in the object (**exclusive relationships**)
 
-Accept an optionnal second param:
+Accept an optional second param:
 
 - `{ oneIsRequired: boolean }` => `true` will return an error if none match, `false` (default) will not throw an error if none match.
 
@@ -496,7 +500,7 @@ alt.object().anyOf('a', 'b', 'c');
 
 ### array().`min(value: int)`
 
-> Force an array to contains at least a number of items equal to the value passed.
+> Force an array to contain at least a number of items equal to the value passed.
 
 ```javascript
 alt.array().min(5);
@@ -504,7 +508,7 @@ alt.array().min(5);
 
 ### array().`max(value: int)`
 
-> Force an array to contains at most a number of items equal to the value passed.
+> Force an array to contain at most a number of items equal to the value passed.
 
 ```javascript
 alt.array().max(10);
@@ -671,7 +675,7 @@ alt.internet().ipv6();
 
 ## Function
 
-There is no method right now, it will only check if the value is valid function.
+There is no method right now, it will only check if the value is a valid function.
 
 ```javascript
 alt.function();

--- a/docs/core-concepts.md
+++ b/docs/core-concepts.md
@@ -10,7 +10,7 @@
 
 ## 👯‍ Creating Instance
 
-To keep reuse validation accros your project, you can create an instance of altheia. All your custom check, templates, lang will follow the instance without modifying the global object.
+To keep reuse validation across your project, you can create an instance of altheia. All your custom check, templates, lang will follow the instance without modifying the global object.
 
 ```javascript
 const copy = alt.instance();
@@ -33,14 +33,14 @@ const errors = await alt({
 Alternative with callbacks
 
 ```javascript
-Alt.string().validate(1, (errors) => {});
+alt.string().validate(1, (errors) => {});
 
-Alt({
-  login: Alt.string(),
+alt({
+  login: alt.string(),
 }).validate({ login: 'foobar' }, (errors) => {});
 ```
 
-This mean you can chain simple check and your database check. Something we used to do in 2 steps in api now can be done seamlessly, for example:
+This mean you can chain a simple check and your database check. Something we used to do in 2 steps in api now can be done seamlessly, for example:
 
 ```javascript
 const newUser = { login: 'admin' };
@@ -57,19 +57,19 @@ const errors = await alt({
 
 ## 💪🏻 Custom check
 
-One thing that all validators miss is... the very custom validation you need for your project. You always want something very precise that will be useful only for you and that does not belongs in the main library. But you don't want to spend hours forking a library or configuring json schema...
+One thing that all validators miss is... the very custom validation you need for your project. You always want something very precise that will be useful only for you and that does not belong in the main library. But you don't want to spend hours forking a library or configuring json schema...
 
 We got you covered with `custom()` validation. We provide the interface, you code:
 
 ```javascript
-Alt.string().custom('wait', async (test) => {
+alt.string().custom('wait', async (test) => {
   return await checkMySuperCustomData(test);
 });
 ```
 
 ## 🗯 Language and Translation
 
-Altheia provides default english error message. If you want to change those, you can easily override language strings by creating a new instance with an object that will be merge with default and/or calling `lang()` to add a new entry on the fly.
+Altheia provides English error messages by default. If you want to change those, you can easily override language strings by creating a new instance with an object that will be merge with default and/or calling `lang()` to add a new entry on the fly.
 
 ```javascript
 const copy = alt.instance({
@@ -78,14 +78,14 @@ const copy = alt.instance({
 ```
 
 ```javascript
-copy.lang('string.min', (name, args) => `This ${name} is not long enough`});
+copy.lang('string.min', (name, args) => `This ${name} is not long enough`);
 ```
 
 ## 🎨 Templates
 
-When you are manipulating a large API, you can feel you are writing the same validation hover and hover. Templates are a very easy way to reduce redundancy in your code and sync all your schemas, while being very light to use.
+When you are manipulating a large API, you can feel you are writing the same validation over and over. Templates are a very easy way to reduce redundancy in your code and sync all your schemas, while being very light to use.
 
-Combined with Instance and Plugins, you can have a master file that import Altheia and declare all your basic input. Then import it everywhere you want.
+Combined with Instance and Plugins, you can have a master file that import Altheia and declare all your basic inputs. Then import it everywhere you want.
 
 ```javascript
 /*** --- myaltheia.ts **/
@@ -106,10 +106,10 @@ alt({
 
 ## 👾 Plugins
 
-In Altheia everything is a plugin. That means even the basic validators are actually plugins. You can easily extends the core of Altheia this way.
+In Altheia everything is a plugin. That means even the basic validators are actually plugins. You can easily extend the core of Altheia this way.
 
 ```javascript
-const copy = Alt.instance();
+const copy = alt.instance();
 
 copy.use({
   messages: {

--- a/todo.md
+++ b/todo.md
@@ -1,7 +1,7 @@
 
 - Plugins / extend capability
 - export as standalone lib
-- test in browserg
+- test in browser
 
 ```
 number


### PR DESCRIPTION
- Harmonized Alt/alt
- Fixed example of how to require in js
- Fixed syntax errors in examples
- Fixed doc typos